### PR TITLE
fix: use fs.writeFileSync

### DIFF
--- a/lib/persistent-undo.coffee
+++ b/lib/persistent-undo.coffee
@@ -21,7 +21,7 @@ module.exports = PersistentUndo =
             @mkdirParent path.dirname(undoFilePath), 0x1ed
           json = JSON.stringify(editor.buffer.historyProvider.serialize({}))
           gzipped = zlib.gzipSync(json)
-          fs.writeFile(undoFilePath, gzipped)
+          fs.writeFileSync(undoFilePath, gzipped)
 
       if editor.buffer?.file?.path?
         undoFolder = atom.config.get('persistent-undo.undoFolder')


### PR DESCRIPTION
This addresses #7 and #9. In Node 10 `fs.writeFile` without a callback parameter has been changed to throw an error (it had been deprecated in previous releases). For a fix we may use `fs.writeFileSync`. We could alternatively use the async version -- I'm not sure of the implications for the functionality of this package.